### PR TITLE
[semver:patch] Remove dependency on wget

### DIFF
--- a/src/scripts/install_bin.sh
+++ b/src/scripts/install_bin.sh
@@ -22,7 +22,7 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 # SOFTWARE.
 
-EXPECTED_CHECKSUM="$(wget -q -O - https://composer.github.io/installer.sig)"
+EXPECTED_CHECKSUM="$(php -r "echo file_get_contents('https://composer.github.io/installer.sig');")"
 php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
 ACTUAL_CHECKSUM="$(php -r "echo hash_file('sha384', 'composer-setup.php');")"
 


### PR DESCRIPTION
The rest of the script is using PHP to do chores, why not the checksum as well? Removing dependency on `wget` can be good since many environments use alpine that does not have it installed by default.